### PR TITLE
Add 'name' property to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "unattended_upgrades"
 maintainer       "Phillip Goldenburg"
 maintainer_email "phillip.goldenburg@sailpoint.com"
 license          "Apache 2.0"


### PR DESCRIPTION
This now seems required by Berkshelf
